### PR TITLE
Fixes SamPrincipalNames > 20 chars from being attempted creating errors

### DIFF
--- a/AD_Users_Create/CreateUsers.ps1
+++ b/AD_Users_Create/CreateUsers.ps1
@@ -259,6 +259,9 @@
             if ($passwordinDesc -lt 10) { 
                 $description = 'Just so I dont forget my password is ' + $pwd 
             }else{}
+    if($name.length -gt 20){
+        $name = $name.substring(0,20)
+    }
     new-aduser -server $setdc  -Description $Description -DisplayName $name -name $name -SamAccountName $name -Surname $name -Enabled $true -Path $ouLocation -AccountPassword (ConvertTo-SecureString ($pwd) -AsPlainText -force)
     
     


### PR DESCRIPTION
Occasionally SAM's greater than 20 characters are attempted which causes errors, this trims them down to 20 before the user create